### PR TITLE
support for apply to pointers to interface{}

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -51,9 +51,14 @@ func getValue(path string, doc interface{}) (*ptr.JsonPointer, reflect.Kind, int
 }
 
 func getDirect(ptr interface{}) (interface{}, error) {
-	indirect := reflect.Indirect(reflect.ValueOf(ptr))
-	if !indirect.IsValid() {
+	ptrval := reflect.ValueOf(ptr)
+	if ptrval.Kind() != reflect.Ptr {
 		return nil, fmt.Errorf("Can only apply to pointers.")
+	}
+
+	indirect := reflect.Indirect(ptrval)
+	if !indirect.IsValid() {
+		return nil, fmt.Errorf("Can not apply to nil pointer.")
 	}
 	return indirect.Interface(), nil
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -288,6 +288,9 @@ func TestAppend(t *testing.T) {
 func TestIntDoc(t *testing.T) {
 	doc := getIntDoc(`{"this": {"is": [1,2,3], "my": {"document": 1}}}`)
 	op := PatchOperation{Op: "add", Path: "/this/my/jam", Value: "!test!"}
+	err := op.Apply(doc)
+	assert.NotNil(t, err)
+
 	op.Apply(&doc)
 	value := getValueAt(op.Path, doc)
 	assert.Equal(t, "!test!", value)


### PR DESCRIPTION
go-jsonpatch returns error in Apply() if source value is defined as interface{}.  but, acutual type may be map[string]interface{} or []interface{}.

For example,  v is defined as interface{} but acutual type is map[string]interface{}.

``` go
package main

import (
        "encoding/json"
        "github.com/cameront/go-jsonpatch"
)

func main() {
        patch, _ := jsonpatch.FromString(`[{ "op": "add", "path": "/baz", "value": "qux" }]`)

        var v interface{}
        json.Unmarshal([]byte(`{"baz":"qux","foo":"bar"}`), &v)

        err := patch.Apply(&v)
        if err != nil {
                // returns "Can only apply to pointers to maps and arrays of interfaces."
                println(err.Error())
        }
}
```

so, I changed type checking method to with actually in this PR.

thank you.
