### PR TITLE
fix a panic if index out of range

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -118,6 +118,9 @@ func add(path string, value interface{}, doc interface{}) error {
 			if index, err = strconv.Atoi(lastToken); err != nil {
 				return err
 			}
+			if index > len(existing) {
+				return fmt.Errorf("Index out of range.")
+			}
 		}
 		existing = append(existing, 0)
 		copy(existing[index+1:], existing[index:])
@@ -169,11 +172,15 @@ func remove(path string, doc interface{}) error {
 		m := parentVal.(map[string]interface{})
 		delete(m, lastToken)
 	case reflect.Slice:
+		existing := parentVal.([]interface{})
 		index, err := strconv.Atoi(lastToken)
 		if err != nil {
 			return err
 		}
-		existing := parentVal.([]interface{})
+		if index > len(existing) {
+			return fmt.Errorf("Index out of range.")
+		}
+
 		existing[index] = nil
 		copy(existing[index:], existing[index+1:])
 		existing = existing[0 : len(existing)-1]
@@ -211,6 +218,10 @@ func replace(path string, value interface{}, doc interface{}) error {
 		if err != nil {
 			return err
 		}
+		if index > len(s) {
+			return fmt.Errorf("Index out of range.")
+		}
+
 		s[index] = value
 	default:
 		return fmt.Errorf("Unable to replace item of kind %s", parentKind)

--- a/operation_test.go
+++ b/operation_test.go
@@ -76,6 +76,10 @@ func TestAddArrayItem(t *testing.T) {
 	patchOp := PatchOperation{Op: "add", Path: "/foo/1", Value: "qux"}
 	patchOp.Apply(&doc)
 	assert.Equal(t, []interface{}{"bar", "qux", "baz"}, doc["foo"].([]interface{}))
+
+	patchOp = PatchOperation{Op: "add", Path: "/foo/4", Value: "qux"}
+	err := patchOp.Apply(&doc)
+	assert.NotNil(t, err)
 }
 
 func TestRemoveObjectKey(t *testing.T) {
@@ -91,6 +95,10 @@ func TestRemoveArrayItem(t *testing.T) {
 	patchOp := PatchOperation{Op: "remove", Path: "/foo/1"}
 	patchOp.Apply(&doc)
 	assert.Equal(t, []interface{}{"bar", "baz"}, doc["foo"].([]interface{}))
+
+	patchOp = PatchOperation{Op: "remove", Path: "/foo/3"}
+	err := patchOp.Apply(&doc)
+	assert.NotNil(t, err)
 }
 
 func TestReplaceObjectKey(t *testing.T) {
@@ -120,6 +128,10 @@ func TestReplaceArrayItem(t *testing.T) {
 	patchOp := PatchOperation{Op: "replace", Path: "/foo/1", Value: "boo"}
 	patchOp.Apply(&doc)
 	assert.Equal(t, []interface{}{"bar", "boo", "baz"}, doc["foo"].([]interface{}))
+
+	patchOp = PatchOperation{Op: "replace", Path: "/foo/4", Value: "boo"}
+	err := patchOp.Apply(&doc)
+	assert.NotNil(t, err)
 }
 
 func TestMoveObjKeyErr(t *testing.T) {


### PR DESCRIPTION
go-jsonpatch panics if pointer's index is outing of range.
So, I fixed this probrem with range checking,  and changed to return error.

thank you.
