### PR TITLE
Uncomments the 'replace the whole doc' tests

### DIFF
--- a/operation_test.go
+++ b/operation_test.go
@@ -109,18 +109,25 @@ func TestReplaceObjectKey(t *testing.T) {
 }
 
 func TestReplaceWholeDocument(t *testing.T) {
-	//doc := getMapDoc(`{"foo":"bar"}`)
-	//patchOp := PatchOperation{Op: "replace", Path: "", Value: map[string]interface{}{"baz": "qux"}}
-	//patchOp.Apply(&doc)
-	//assert.Equal(t, "quz", doc["baz"].(string))
+	doc := getMapDoc(`{"foo":"bar"}`)
+	patchOp := PatchOperation{Op: "replace", Path: "", Value: map[string]interface{}{"baz": "qux"}}
+	patchOp.Apply(&doc)
+	assert.Equal(t, "qux", doc["baz"].(string))
 }
 
 func TestAddReplaceWholeDocument(t *testing.T) {
-	//doc := getMapDoc(`{"foo":"bar"}`)
-	//patchOp := PatchOperation{Op: "add", Path: "", Value: map[string]interface{}{"baz": "qux"}}
-	//patchOp.Apply(&doc)
-	//assert.Equal(t, 1, len(doc))
-	//assert.Equal(t, "qux", doc["baz"].(string))
+	doc := getMapDoc(`{"foo":"bar"}`)
+	patchOp := PatchOperation{Op: "add", Path: "", Value: map[string]interface{}{"baz": "qux"}}
+	patchOp.Apply(&doc)
+	assert.Equal(t, 1, len(doc))
+	assert.Equal(t, "qux", doc["baz"].(string))
+}
+
+func TestErrIfPtrNotPassed(t *testing.T) {
+	doc := getMapDoc(`{"foo":"bar"}`)
+	patchOp := PatchOperation{Op: "replace", Path: "", Value: map[string]interface{}{"baz": "qux"}}
+	err := patchOp.Apply(doc)
+	assert.NotNil(t, err)
 }
 
 func TestReplaceArrayItem(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -12,6 +12,8 @@ func TestMakePatch(t *testing.T) {
 	patch, err := MakePatch(docA, docB)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(patch.Operations))
+	// TODO: This test must depend on the ordering of a map iteration, because I'm getting
+	// occasional failures occasionally with the ordering of the following two lines.
 	assert.Equal(t, PatchOperation{Op: "replace", Path: "/this/is", Value: "sir"}, patch.Operations[0])
 	assert.Equal(t, PatchOperation{Op: "replace", Path: "/this/document", Value: "my"}, patch.Operations[1])
 	assert.Equal(t, PatchOperation{Op: "add", Path: "/this/now", Value: map[string]interface{}{"go": "away!"}}, patch.Operations[2])


### PR DESCRIPTION
Also noticed an issue with the patch test that I suspect relies on the iteration order of a map (which go specifically does not guarantee to be deterministic)
