### PR TITLE
fixed append patch's test case

### DIFF
--- a/operation_test.go
+++ b/operation_test.go
@@ -2,10 +2,11 @@ package jsonpatch
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	ptr "github.com/xeipuuv/gojsonpointer"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ptr "github.com/xeipuuv/gojsonpointer"
 )
 
 func TestAdd(t *testing.T) {
@@ -297,12 +298,12 @@ func TestUnrecognizedElement(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
-	doc := getMapDoc(`{"foo": [1, 2]}`)
-	patch1 := PatchOperation{Op: "add", Path: "/foo/-", Value: 3}
-	patch2 := PatchOperation{Op: "add", Path: "/foo/-", Value: 4}
+	doc := getMapDoc(`{"foo": ["a", "b"]}`)
+	patch1 := PatchOperation{Op: "add", Path: "/foo/-", Value: "c"}
+	patch2 := PatchOperation{Op: "add", Path: "/foo/-", Value: "d"}
 	patch1.Apply(&doc)
 	patch2.Apply(&doc)
-	assert.Equal(t, []interface{}{1, 2, 3, 4}, doc["foo"].([]interface{}))
+	assert.Equal(t, []interface{}{"a", "b", "c", "d"}, doc["foo"].([]interface{}))
 }
 
 // test when type of input is interface{}


### PR DESCRIPTION
The  test case is failed on `go version go1.9.2 darwin/amd64`

Test output is following:
```
--- FAIL: TestAppend (0.00s)
	operation_test.go:305:
			Error Trace:	operation_test.go:305
			Error:      	Not equal:
			            	expected: []interface {}{1, 2, 3, 4}
			            	actual  : []interface {}{1, 2, 3, 4}

			            	Diff:
			            	--- Expected
			            	+++ Actual
			            	@@ -1,4 +1,4 @@
			            	 ([]interface {}) (len=4) {
			            	- (int) 1,
			            	- (int) 2,
			            	+ (float64) 1,
			            	+ (float64) 2,
			            	  (int) 3,
			Test:       	TestAppend
FAIL
exit status 1
FAIL	github.com/cameront/go-jsonpatch	0.011s
```

The `[1, 2]` JSON is parsed as `float64`, but actual value is defined as `int`. so these are mis-matched.

In this test case, it is not necessity that foo array's value is number.
So this patch changes the type from number to string.